### PR TITLE
Added supports to using Markdown and HTML formatted messages

### DIFF
--- a/lib/fastlane/plugin/telegram/actions/telegram_action.rb
+++ b/lib/fastlane/plugin/telegram/actions/telegram_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         parse_mode = params[:parse_mode]
 
         uri = URI.parse("https://api.telegram.org/bot#{token}/sendMessage")
-        response = Net::HTTP.post_form(uri, {:chat_id => chat_id, :text => text})
+        response = Net::HTTP.post_form(uri, {:chat_id => chat_id, :text => text, :parse_mode => parse_mode})
       end
 
       def self.description

--- a/lib/fastlane/plugin/telegram/actions/telegram_action.rb
+++ b/lib/fastlane/plugin/telegram/actions/telegram_action.rb
@@ -48,7 +48,7 @@ module Fastlane
                                                type: String)
                    FastlaneCore::ConfigItem.new(key: :parse_mode,
                                            env_name: "TELEGRAM_PARSE_MODE",
-                                        description: "Flag for using markdown or HTML support in message",
+                                        description: "Param (Markdown / HTML) for using markdown or HTML support in message.",
                                            optional: true,
                                                type: String)
                 ]

--- a/lib/fastlane/plugin/telegram/actions/telegram_action.rb
+++ b/lib/fastlane/plugin/telegram/actions/telegram_action.rb
@@ -7,6 +7,7 @@ module Fastlane
         token = params[:token]
         chat_id = params[:chat_id]
         text = params[:text]
+        parse_mode = params[:parse_mode]
 
         uri = URI.parse("https://api.telegram.org/bot#{token}/sendMessage")
         response = Net::HTTP.post_form(uri, {:chat_id => chat_id, :text => text})
@@ -44,6 +45,11 @@ module Fastlane
                                            env_name: "TELEGRAM_TEXT",
                                         description: "Text of the message to be sent",
                                            optional: false,
+                                               type: String)
+                   FastlaneCore::ConfigItem.new(key: :parse_mode,
+                                           env_name: "TELEGRAM_PARSE_MODE",
+                                        description: "Flag for using markdown or HTML support in message",
+                                           optional: true,
                                                type: String)
                 ]
       end


### PR DESCRIPTION
https://core.telegram.org/bots/api/#formatting-options